### PR TITLE
use absolute paths and dont rewrite path including assets

### DIFF
--- a/now.json
+++ b/now.json
@@ -1,3 +1,0 @@
-{
-    "rewrites": [{ "source": "/(.*)", "destination": "/" }]
-}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+    "rewrites": [
+        {
+            "source": "/((?!assets/).*)",
+            "destination": "/"
+        }
+    ]
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -6,5 +6,5 @@ import mkcert from "vite-plugin-mkcert";
 export default defineConfig({
     server: { https: true },
     plugins: [react(), mkcert()],
-    base: "./",
+    base: "/",
 });


### PR DESCRIPTION
1. `now.json` si deprecated, renamed to `vercel.json`
2. rewriting everything essentially rewrote the URL for serving static files too, so everything just served index.html
3. use absolute paths because filesystem routes should be handles absolutely since they are static